### PR TITLE
LICENSE: use https for all URLs

### DIFF
--- a/LICENSE
+++ b/LICENSE
@@ -1,4 +1,4 @@
-Format: http://www.debian.org/doc/packaging-manuals/copyright-format/1.0/
+Format: https://www.debian.org/doc/packaging-manuals/copyright-format/1.0/
 Comment: This file documents the copyright statements and licenses for
  every file in this package in a machine-readable format.  For a less
  detailed, higher-level overview, see README.
@@ -144,7 +144,7 @@ License: GPL-2+ with Autoconf exception
  Public License for more details.
  .
  You should have received a copy of the GNU General Public License along
- with this program.  If not, see <http://www.gnu.org/licenses/>.
+ with this program.  If not, see <https://www.gnu.org/licenses/>.
  .
  As a special exception to the GNU General Public License, if you
  distribute this file as part of a program that contains a configuration


### PR DESCRIPTION
DEP-5 supports the secure address of the machine-readable
debian/copyright format.  and www.gnu.org has supported https for
years now.