### PR TITLE
Add test_cleanup_register_with_data

### DIFF
--- a/tests/tap/basic.h
+++ b/tests/tap/basic.h
@@ -174,6 +174,14 @@ typedef void (*test_cleanup_func)(int, int);
 void test_cleanup_register(test_cleanup_func)
     __attribute__((__nonnull__));
 
+/*
+ * Same as above, but also allows an opaque pointer to be passed to the cleanup
+ * function.
+ */
+typedef void (*test_cleanup_func_with_data)(int, int, void *);
+void test_cleanup_register_with_data(test_cleanup_func_with_data, void *)
+    __attribute__((__nonnull__));
+
 END_DECLS
 
 #endif /* TAP_BASIC_H */


### PR DESCRIPTION
Add a new variant of test_cleanup_register that allows an opaque
pointer to be passed to the registered cleanup function.  This can
be useful to pass in information that can be used for the cleanup,
such as file/directory names, etc.