### PR TITLE
Add test_cleanup_register_with_data

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -49,6 +49,7 @@
 /tests/libtap/cleanup/c-many-fail
 /tests/libtap/cleanup/c-one
 /tests/libtap/cleanup/c-one-fail
+/tests/libtap/cleanup/c-one-with-data
 /tests/runtests
 /tmp-valgrind/
 .deps/

--- a/Makefile.am
+++ b/Makefile.am
@@ -91,6 +91,7 @@ EXTRA_DIST = .gitignore LICENSE README.md bootstrap docs/api/bail.pod	    \
 	tests/libtap/cleanup/c-lazy.output				    \
 	tests/libtap/cleanup/c-many-fail.output				    \
 	tests/libtap/cleanup/c-many.output				    \
+	tests/libtap/cleanup/c-one-with-data.output			    \
 	tests/libtap/cleanup/c-one-fail.output				    \
 	tests/libtap/cleanup/c-one.output tests/tap/libtap.sh		    \
 	tests/tap/perl/Test/RRA.pm tests/tap/perl/Test/RRA/Automake.pm	    \
@@ -198,7 +199,7 @@ check_PROGRAMS = tests/libtap/basic/c-bail tests/libtap/basic/c-basic	\
 	tests/libtap/cleanup/c-bail-lazy tests/libtap/cleanup/c-fork	\
 	tests/libtap/cleanup/c-lazy tests/libtap/cleanup/c-many		\
 	tests/libtap/cleanup/c-many-fail tests/libtap/cleanup/c-one	\
-	tests/libtap/cleanup/c-one-fail
+	tests/libtap/cleanup/c-one-fail tests/libtap/cleanup/c-one-with-data
 tests_libtap_basic_c_bail_LDADD = tests/tap/libtap.a -lm
 tests_libtap_basic_c_basic_LDADD = tests/tap/libtap.a -lm
 tests_libtap_basic_c_bstrndup_LDADD = tests/tap/libtap.a -lm
@@ -224,6 +225,7 @@ tests_libtap_cleanup_c_many_LDADD = tests/tap/libtap.a -lm
 tests_libtap_cleanup_c_many_fail_LDADD = tests/tap/libtap.a -lm
 tests_libtap_cleanup_c_one_LDADD = tests/tap/libtap.a -lm
 tests_libtap_cleanup_c_one_fail_LDADD = tests/tap/libtap.a -lm
+tests_libtap_cleanup_c_one_with_data_LDADD = tests/tap/libtap.a -lm
 
 check-local: $(bin_PROGRAMS) $(check_PROGRAMS)
 	cd tests && ./runtests -s '$(abs_top_srcdir)/tests' \

--- a/docs/api/test_cleanup_register.pod
+++ b/docs/api/test_cleanup_register.pod
@@ -3,7 +3,7 @@ Allbery typedef FSFAP SPDX-License-Identifier
 
 =head1 NAME
 
-test_cleanup_register - Register a function to run at the end of a TAP test
+test_cleanup_register, test_cleanup_register_with_data - Register a function to run at the end of a TAP test
 
 =head1 SYNOPSIS
 
@@ -11,7 +11,11 @@ test_cleanup_register - Register a function to run at the end of a TAP test
 
 typedef void (*B<test_cleanup_func>)(int, int);
 
+typedef void (*B<test_cleanup_func_with_data>)(int, int, void *);
+
 void B<test_cleanup_register>(test_cleanup_func I<func>);
+
+void B<test_cleanup_register_with_data>(test_cleanup_func_with_data I<func>, void *I<data>);
 
 =head1 DESCRIPTION
 
@@ -40,6 +44,11 @@ if the test aborts with bail().
 test_cleanup_register() may be called as many times as desired.  All
 registered functions will be called (provided that none of them terminate
 the process prematurely) in the order in which they were registered.
+
+test_cleanup_register_with_data() functions as described above, except that
+the additional opaque pointer is passed on to the registered function.  This
+can be useful to pass data such as directory or file names to the cleanup
+function, rather than relying on global variables.
 
 =head1 RETURN VALUE
 

--- a/tests/libtap/cleanup-t
+++ b/tests/libtap/cleanup-t
@@ -27,7 +27,7 @@ ok_test_program () {
 }
 
 # Total tests.
-plan `expr 8 \* 2`
+plan `expr 9 \* 2`
 
 # Run the individual tests.
 ok_test_program c-bail      255
@@ -38,3 +38,4 @@ ok_test_program c-many      0
 ok_test_program c-many-fail 0
 ok_test_program c-one       0
 ok_test_program c-one-fail  0
+ok_test_program c-one-with-data       0

--- a/tests/libtap/cleanup/c-one-with-data.c
+++ b/tests/libtap/cleanup/c-one-with-data.c
@@ -1,0 +1,30 @@
+/*
+ * Test of the libtap test_cleanup_register_with_data function with one cleanup.
+ *
+ * See LICENSE for licensing terms.
+ */
+
+#include <stdio.h>
+#include <stdint.h>
+
+#include <tests/tap/basic.h>
+
+
+/*
+ * The test function to call during cleanup.
+ */
+static void
+test(int success, int primary, void *data)
+{
+    printf("Called cleanup with %d %d %d\n", success, primary, (int)(intptr_t)data);
+}
+
+
+int
+main(void)
+{
+    test_cleanup_register_with_data(test, (void *)99);
+    plan(1);
+    ok(1, "some test");
+    return 0;
+}

--- a/tests/libtap/cleanup/c-one-with-data.output
+++ b/tests/libtap/cleanup/c-one-with-data.output
@@ -1,0 +1,4 @@
+1..1
+ok 1 - some test
+Called cleanup with 1 1 99
+# 1 test successful or skipped

--- a/tests/tap/basic.h
+++ b/tests/tap/basic.h
@@ -174,6 +174,14 @@ typedef void (*test_cleanup_func)(int, int);
 void test_cleanup_register(test_cleanup_func)
     __attribute__((__nonnull__));
 
+/*
+ * Same as above, but also allows an opaque pointer to be passed to the cleanup
+ * function.
+ */
+typedef void (*test_cleanup_func_with_data)(int, int, void *);
+void test_cleanup_register_with_data(test_cleanup_func_with_data, void *)
+    __attribute__((__nonnull__));
+
 END_DECLS
 
 #endif /* TAP_BASIC_H */


### PR DESCRIPTION
Add a new variant of test_cleanup_register that allows an opaque
pointer to be passed to the registered cleanup function.  This can
be useful to pass in information that can be used for the cleanup,
such as file/directory names, etc.