### PR TITLE
runtests: Remove an obsolete check for n gt 0

### DIFF
--- a/tests/runtests.c
+++ b/tests/runtests.c
@@ -390,7 +390,7 @@ x_reallocarray(void *p, size_t n, size_t size, const char *file, int line)
     n = (n > 0) ? n : 1;
     size = (size > 0) ? size : 1;
 
-    if (n > 0 && UINT_MAX / n <= size)
+    if (UINT_MAX / n <= size)
         sysdie("realloc too large at %s line %d", file, line);
     p = realloc(p, n * size);
     if (p == NULL)


### PR DESCRIPTION
The obsolete check can never fail
(The previous commit made sure, that n is at least 1)

--
bye bye Detlef

Signed-off-by: Detlef Riekenberg <wine.dev@web.de>