### PR TITLE
fix: Remove dead code (Revert "Fix x_reallocarray guard")

### DIFF
--- a/tests/runtests.c
+++ b/tests/runtests.c
@@ -408,7 +408,7 @@ x_reallocarray(void *p, size_t n, size_t size, const char *file, int line)
     n = (n > 0) ? n : 1;
     size = (size > 0) ? size : 1;
 
-    if (n > 0 && UINT_MAX / n <= size)
+    if (UINT_MAX / n <= size)
         sysdie("realloc too large at %s line %d", file, line);
     p = realloc(p, n * size);
     if (p == NULL)


### PR DESCRIPTION
This reverts commit 599c10937af8a5c1b6f779df33c13a363de61dd0.

The reverted patch introduced again a dead code check. 
The variable n can never 0 in this location and a divide by zero is never possible


Long code flow description:
For the case, that the function x_reallocarray is called with zero for n, 
the first line in the function x_reallocarray makes sure, that n is at least 1
for the following code.
```
n = (n > 0) ? n : 1;
```
https://github.com/rra/c-tap-harness/blob/main/tests/runtests.c#L408

The reverted commit added a check "n > 0", which can never fail.

The code was already fixed in Sep. 2021, but the reverted commit added the dead code again.

--
Regards ... Detlef
